### PR TITLE
make sure no randomness is used when randomizationFactor is 0

### DIFF
--- a/exponential.go
+++ b/exponential.go
@@ -147,6 +147,9 @@ func (b *ExponentialBackOff) incrementCurrentInterval() {
 // Returns a random value from the following interval:
 // 	[currentInterval - randomizationFactor * currentInterval, currentInterval + randomizationFactor * currentInterval].
 func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	if randomizationFactor == 0 {
+		return currentInterval // make sure no randomness is used when randomizationFactor is 0.
+	}
 	var delta = randomizationFactor * float64(currentInterval)
 	var minInterval = float64(currentInterval) - delta
 	var maxInterval = float64(currentInterval) + delta


### PR DESCRIPTION
in current implementation there is the following issue - it's not possible to disable randomization.
I'd expect that if I set randomizationFactor to 0, no randomness will be done.

I've updated the code accordingly to fix the issue.